### PR TITLE
chore: lock files maintenance

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1907,9 +1907,9 @@
       "integrity": "sha512-ZXyOOm83p7X8p3s0IYM3VeueNmHpkk/yMlP8CLeOnEcu6hIwPH7YjZBvhQkR0ZFS2DqZAxKtJ/M5fcuv3OU5BA=="
     },
     "@types/node": {
-      "version": "8.10.11",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-8.10.11.tgz",
-      "integrity": "sha512-FM7tvbjbn2BUzM/Qsdk9LUGq3zeh7li8NcHoS398dBzqLzfmSqSP1+yKbMRTCcZzLcu2JAR5lq3IKIEYkto7iQ=="
+      "version": "8.10.12",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-8.10.12.tgz",
+      "integrity": "sha512-aRFUGj/f9JVA0qSQiCK9ebaa778mmqMIcy1eKnPktgfm9O6VsnIzzB5wJnjp9/jVrfm7fX1rr3OR1nndppGZUg=="
     },
     "acorn": {
       "version": "4.0.13",
@@ -2682,7 +2682,7 @@
         "babel-generator": "6.26.1",
         "babylon": "6.18.0",
         "call-matcher": "1.0.1",
-        "core-js": "2.5.5",
+        "core-js": "2.5.6",
         "espower-location-detector": "1.0.0",
         "espurify": "1.7.0",
         "estraverse": "4.2.0"
@@ -2829,7 +2829,7 @@
       "requires": {
         "babel-core": "6.26.3",
         "babel-runtime": "6.26.0",
-        "core-js": "2.5.5",
+        "core-js": "2.5.6",
         "home-or-tmp": "2.0.0",
         "lodash": "4.17.10",
         "mkdirp": "0.5.1",
@@ -2853,7 +2853,7 @@
       "integrity": "sha1-llxwWGaOgrVde/4E/yM3vItWR/4=",
       "dev": true,
       "requires": {
-        "core-js": "2.5.5",
+        "core-js": "2.5.6",
         "regenerator-runtime": "0.11.1"
       }
     },
@@ -3206,7 +3206,7 @@
       "integrity": "sha1-UTTQd5hPcSpU2tPL9i3ijc5BbKg=",
       "dev": true,
       "requires": {
-        "core-js": "2.5.5",
+        "core-js": "2.5.6",
         "deep-equal": "1.0.1",
         "espurify": "1.7.0",
         "estraverse": "4.2.0"
@@ -3677,9 +3677,9 @@
       }
     },
     "core-js": {
-      "version": "2.5.5",
-      "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.5.5.tgz",
-      "integrity": "sha1-sU3ek2xkDAV5prUMq8wTLdYSfjs="
+      "version": "2.5.6",
+      "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.5.6.tgz",
+      "integrity": "sha512-lQUVfQi0aLix2xpyjrrJEvfuYCqPc/HwmTKsC/VNf8q0zsjX7SQZtp4+oRONN5Tsur9GDETPjj+Ub2iDiGZfSQ=="
     },
     "core-util-is": {
       "version": "1.0.2",
@@ -4007,9 +4007,9 @@
       "dev": true
     },
     "duplexify": {
-      "version": "3.5.4",
-      "resolved": "https://registry.npmjs.org/duplexify/-/duplexify-3.5.4.tgz",
-      "integrity": "sha512-JzYSLYMhoVVBe8+mbHQ4KgpvHpm0DZpJuL8PY93Vyv1fW7jYJ90LoXa1di/CVbJM+TgMs91rbDapE/RNIfnJsA==",
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/duplexify/-/duplexify-3.6.0.tgz",
+      "integrity": "sha512-fO3Di4tBKJpYTFHAxTU00BcfWMY9w24r/x21a6rZRbsD/ToUgGxsMbiGRmB7uVAXeGKXD9MwiLZa5E97EVgIRQ==",
       "requires": {
         "end-of-stream": "1.4.1",
         "inherits": "2.0.3",
@@ -4045,7 +4045,7 @@
       "resolved": "https://registry.npmjs.org/empower/-/empower-1.2.3.tgz",
       "integrity": "sha1-bw2nNEf07dg4/sXGAxOoi6XLhSs=",
       "requires": {
-        "core-js": "2.5.5",
+        "core-js": "2.5.6",
         "empower-core": "0.6.2"
       }
     },
@@ -4064,7 +4064,7 @@
       "integrity": "sha1-Wt71ZgiOMfuoC6CjbfR9cJQWkUQ=",
       "requires": {
         "call-signature": "0.0.2",
-        "core-js": "2.5.5"
+        "core-js": "2.5.6"
       }
     },
     "end-of-stream": {
@@ -4491,7 +4491,7 @@
       "resolved": "https://registry.npmjs.org/espurify/-/espurify-1.7.0.tgz",
       "integrity": "sha1-HFz2y8zDLm9jk4C9T5kfq5up0iY=",
       "requires": {
-        "core-js": "2.5.5"
+        "core-js": "2.5.6"
       }
     },
     "esquery": {
@@ -4662,7 +4662,7 @@
       "dev": true,
       "requires": {
         "chardet": "0.4.2",
-        "iconv-lite": "0.4.21",
+        "iconv-lite": "0.4.22",
         "tmp": "0.0.33"
       }
     },
@@ -4749,7 +4749,7 @@
         "@mrmlnc/readdir-enhanced": "2.2.1",
         "glob-parent": "3.1.0",
         "is-glob": "4.0.0",
-        "merge2": "1.2.1",
+        "merge2": "1.2.2",
         "micromatch": "3.1.10"
       }
     },
@@ -5670,12 +5670,12 @@
       "resolved": "https://registry.npmjs.org/google-gax/-/google-gax-0.16.1.tgz",
       "integrity": "sha512-eP7UUkKvaHmmvCrr+rxzkIOeEKOnXmoib7/AkENDAuqlC9T2+lWlzwpthDRnitQcV8SblDMzsk73YPMPCDwPyQ==",
       "requires": {
-        "duplexify": "3.5.4",
+        "duplexify": "3.6.0",
         "extend": "3.0.1",
         "globby": "8.0.1",
         "google-auto-auth": "0.10.1",
         "google-proto-files": "0.15.1",
-        "grpc": "1.11.0",
+        "grpc": "1.11.3",
         "is-stream-ended": "0.1.4",
         "lodash": "4.17.10",
         "protobufjs": "6.8.6",
@@ -5771,29 +5771,19 @@
       "dev": true
     },
     "grpc": {
-      "version": "1.11.0",
-      "resolved": "https://registry.npmjs.org/grpc/-/grpc-1.11.0.tgz",
-      "integrity": "sha512-pTJjV/eatBQ6Rhc/jWNmUW9jE8fPrhcMYSWDSyf4l7ah1U3sIe4eIjqI/a3sm0zKbM5CuovV0ESrc+b04kr4Ig==",
+      "version": "1.11.3",
+      "resolved": "https://registry.npmjs.org/grpc/-/grpc-1.11.3.tgz",
+      "integrity": "sha512-7fJ40USpnP7hxGK0uRoEhJz6unA5VUdwInfwAY2rK2+OVxdDJSdTZQ/8/M+1tW68pHZYgHvg2ohvJ+clhW3ANg==",
       "requires": {
         "lodash": "4.17.10",
         "nan": "2.10.0",
-        "node-pre-gyp": "0.7.0",
+        "node-pre-gyp": "0.10.0",
         "protobufjs": "5.0.2"
       },
       "dependencies": {
         "abbrev": {
           "version": "1.1.1",
           "bundled": true
-        },
-        "ajv": {
-          "version": "5.5.2",
-          "bundled": true,
-          "requires": {
-            "co": "4.6.0",
-            "fast-deep-equal": "1.1.0",
-            "fast-json-stable-stringify": "2.0.0",
-            "json-schema-traverse": "0.3.1"
-          }
         },
         "ansi-regex": {
           "version": "2.1.1",
@@ -5811,51 +5801,9 @@
             "readable-stream": "2.3.6"
           }
         },
-        "asn1": {
-          "version": "0.2.3",
-          "bundled": true
-        },
-        "assert-plus": {
-          "version": "1.0.0",
-          "bundled": true
-        },
-        "asynckit": {
-          "version": "0.4.0",
-          "bundled": true
-        },
-        "aws-sign2": {
-          "version": "0.7.0",
-          "bundled": true
-        },
-        "aws4": {
-          "version": "1.7.0",
-          "bundled": true
-        },
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true
-        },
-        "bcrypt-pbkdf": {
-          "version": "1.0.1",
-          "bundled": true,
-          "optional": true,
-          "requires": {
-            "tweetnacl": "0.14.5"
-          }
-        },
-        "block-stream": {
-          "version": "0.0.9",
-          "bundled": true,
-          "requires": {
-            "inherits": "2.0.3"
-          }
-        },
-        "boom": {
-          "version": "4.3.1",
-          "bundled": true,
-          "requires": {
-            "hoek": "4.2.1"
-          }
         },
         "brace-expansion": {
           "version": "1.1.11",
@@ -5865,24 +5813,13 @@
             "concat-map": "0.0.1"
           }
         },
-        "caseless": {
-          "version": "0.12.0",
-          "bundled": true
-        },
-        "co": {
-          "version": "4.6.0",
+        "chownr": {
+          "version": "1.0.1",
           "bundled": true
         },
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true
-        },
-        "combined-stream": {
-          "version": "1.0.6",
-          "bundled": true,
-          "requires": {
-            "delayed-stream": "1.0.0"
-          }
         },
         "concat-map": {
           "version": "0.0.1",
@@ -5896,29 +5833,6 @@
           "version": "1.0.2",
           "bundled": true
         },
-        "cryptiles": {
-          "version": "3.1.2",
-          "bundled": true,
-          "requires": {
-            "boom": "5.2.0"
-          },
-          "dependencies": {
-            "boom": {
-              "version": "5.2.0",
-              "bundled": true,
-              "requires": {
-                "hoek": "4.2.1"
-              }
-            }
-          }
-        },
-        "dashdash": {
-          "version": "1.14.1",
-          "bundled": true,
-          "requires": {
-            "assert-plus": "1.0.0"
-          }
-        },
         "debug": {
           "version": "2.6.9",
           "bundled": true,
@@ -5927,11 +5841,7 @@
           }
         },
         "deep-extend": {
-          "version": "0.4.2",
-          "bundled": true
-        },
-        "delayed-stream": {
-          "version": "1.0.0",
+          "version": "0.5.1",
           "bundled": true
         },
         "delegates": {
@@ -5942,65 +5852,16 @@
           "version": "1.0.3",
           "bundled": true
         },
-        "ecc-jsbn": {
-          "version": "0.1.1",
-          "bundled": true,
-          "optional": true,
-          "requires": {
-            "jsbn": "0.1.1"
-          }
-        },
-        "extend": {
-          "version": "3.0.1",
-          "bundled": true
-        },
-        "extsprintf": {
-          "version": "1.3.0",
-          "bundled": true
-        },
-        "fast-deep-equal": {
-          "version": "1.1.0",
-          "bundled": true
-        },
-        "fast-json-stable-stringify": {
-          "version": "2.0.0",
-          "bundled": true
-        },
-        "forever-agent": {
-          "version": "0.6.1",
-          "bundled": true
-        },
-        "form-data": {
-          "version": "2.3.2",
+        "fs-minipass": {
+          "version": "1.2.5",
           "bundled": true,
           "requires": {
-            "asynckit": "0.4.0",
-            "combined-stream": "1.0.6",
-            "mime-types": "2.1.18"
+            "minipass": "2.2.4"
           }
         },
         "fs.realpath": {
           "version": "1.0.0",
           "bundled": true
-        },
-        "fstream": {
-          "version": "1.0.11",
-          "bundled": true,
-          "requires": {
-            "graceful-fs": "4.1.11",
-            "inherits": "2.0.3",
-            "mkdirp": "0.5.1",
-            "rimraf": "2.6.2"
-          }
-        },
-        "fstream-ignore": {
-          "version": "1.0.5",
-          "bundled": true,
-          "requires": {
-            "fstream": "1.0.11",
-            "inherits": "2.0.3",
-            "minimatch": "3.0.4"
-          }
         },
         "gauge": {
           "version": "2.7.4",
@@ -6016,13 +5877,6 @@
             "wide-align": "1.1.2"
           }
         },
-        "getpass": {
-          "version": "0.1.7",
-          "bundled": true,
-          "requires": {
-            "assert-plus": "1.0.0"
-          }
-        },
         "glob": {
           "version": "7.1.2",
           "bundled": true,
@@ -6035,47 +5889,19 @@
             "path-is-absolute": "1.0.1"
           }
         },
-        "graceful-fs": {
-          "version": "4.1.11",
-          "bundled": true
-        },
-        "har-schema": {
-          "version": "2.0.0",
-          "bundled": true
-        },
-        "har-validator": {
-          "version": "5.0.3",
-          "bundled": true,
-          "requires": {
-            "ajv": "5.5.2",
-            "har-schema": "2.0.0"
-          }
-        },
         "has-unicode": {
           "version": "2.0.1",
           "bundled": true
         },
-        "hawk": {
-          "version": "6.0.2",
-          "bundled": true,
-          "requires": {
-            "boom": "4.3.1",
-            "cryptiles": "3.1.2",
-            "hoek": "4.2.1",
-            "sntp": "2.1.0"
-          }
-        },
-        "hoek": {
-          "version": "4.2.1",
+        "iconv-lite": {
+          "version": "0.4.19",
           "bundled": true
         },
-        "http-signature": {
-          "version": "1.2.0",
+        "ignore-walk": {
+          "version": "3.0.1",
           "bundled": true,
           "requires": {
-            "assert-plus": "1.0.0",
-            "jsprim": "1.4.1",
-            "sshpk": "1.14.1"
+            "minimatch": "3.0.4"
           }
         },
         "inflight": {
@@ -6101,55 +5927,9 @@
             "number-is-nan": "1.0.1"
           }
         },
-        "is-typedarray": {
-          "version": "1.0.0",
-          "bundled": true
-        },
         "isarray": {
           "version": "1.0.0",
           "bundled": true
-        },
-        "isstream": {
-          "version": "0.1.2",
-          "bundled": true
-        },
-        "jsbn": {
-          "version": "0.1.1",
-          "bundled": true,
-          "optional": true
-        },
-        "json-schema": {
-          "version": "0.2.3",
-          "bundled": true
-        },
-        "json-schema-traverse": {
-          "version": "0.3.1",
-          "bundled": true
-        },
-        "json-stringify-safe": {
-          "version": "5.0.1",
-          "bundled": true
-        },
-        "jsprim": {
-          "version": "1.4.1",
-          "bundled": true,
-          "requires": {
-            "assert-plus": "1.0.0",
-            "extsprintf": "1.3.0",
-            "json-schema": "0.2.3",
-            "verror": "1.10.0"
-          }
-        },
-        "mime-db": {
-          "version": "1.33.0",
-          "bundled": true
-        },
-        "mime-types": {
-          "version": "2.1.18",
-          "bundled": true,
-          "requires": {
-            "mime-db": "1.33.0"
-          }
         },
         "minimatch": {
           "version": "3.0.4",
@@ -6161,6 +5941,21 @@
         "minimist": {
           "version": "1.2.0",
           "bundled": true
+        },
+        "minipass": {
+          "version": "2.2.4",
+          "bundled": true,
+          "requires": {
+            "safe-buffer": "5.1.1",
+            "yallist": "3.0.2"
+          }
+        },
+        "minizlib": {
+          "version": "1.1.0",
+          "bundled": true,
+          "requires": {
+            "minipass": "2.2.4"
+          }
         },
         "mkdirp": {
           "version": "0.5.1",
@@ -6179,20 +5974,29 @@
           "version": "2.0.0",
           "bundled": true
         },
+        "needle": {
+          "version": "2.2.1",
+          "bundled": true,
+          "requires": {
+            "debug": "2.6.9",
+            "iconv-lite": "0.4.19",
+            "sax": "1.2.4"
+          }
+        },
         "node-pre-gyp": {
-          "version": "0.7.0",
+          "version": "0.10.0",
           "bundled": true,
           "requires": {
             "detect-libc": "1.0.3",
             "mkdirp": "0.5.1",
+            "needle": "2.2.1",
             "nopt": "4.0.1",
+            "npm-packlist": "1.1.10",
             "npmlog": "4.1.2",
-            "rc": "1.2.6",
-            "request": "2.83.0",
+            "rc": "1.2.7",
             "rimraf": "2.6.2",
             "semver": "5.5.0",
-            "tar": "2.2.1",
-            "tar-pack": "3.4.1"
+            "tar": "4.4.2"
           }
         },
         "nopt": {
@@ -6201,6 +6005,18 @@
           "requires": {
             "abbrev": "1.1.1",
             "osenv": "0.1.5"
+          }
+        },
+        "npm-bundled": {
+          "version": "1.0.3",
+          "bundled": true
+        },
+        "npm-packlist": {
+          "version": "1.1.10",
+          "bundled": true,
+          "requires": {
+            "ignore-walk": "3.0.1",
+            "npm-bundled": "1.0.3"
           }
         },
         "npmlog": {
@@ -6215,10 +6031,6 @@
         },
         "number-is-nan": {
           "version": "1.0.1",
-          "bundled": true
-        },
-        "oauth-sign": {
-          "version": "0.8.2",
           "bundled": true
         },
         "object-assign": {
@@ -6252,10 +6064,6 @@
           "version": "1.0.1",
           "bundled": true
         },
-        "performance-now": {
-          "version": "2.1.0",
-          "bundled": true
-        },
         "process-nextick-args": {
           "version": "2.0.0",
           "bundled": true
@@ -6271,19 +6079,11 @@
             "yargs": "3.32.0"
           }
         },
-        "punycode": {
-          "version": "1.4.1",
-          "bundled": true
-        },
-        "qs": {
-          "version": "6.5.1",
-          "bundled": true
-        },
         "rc": {
-          "version": "1.2.6",
+          "version": "1.2.7",
           "bundled": true,
           "requires": {
-            "deep-extend": "0.4.2",
+            "deep-extend": "0.5.1",
             "ini": "1.3.5",
             "minimist": "1.2.0",
             "strip-json-comments": "2.0.1"
@@ -6302,34 +6102,6 @@
             "util-deprecate": "1.0.2"
           }
         },
-        "request": {
-          "version": "2.83.0",
-          "bundled": true,
-          "requires": {
-            "aws-sign2": "0.7.0",
-            "aws4": "1.7.0",
-            "caseless": "0.12.0",
-            "combined-stream": "1.0.6",
-            "extend": "3.0.1",
-            "forever-agent": "0.6.1",
-            "form-data": "2.3.2",
-            "har-validator": "5.0.3",
-            "hawk": "6.0.2",
-            "http-signature": "1.2.0",
-            "is-typedarray": "1.0.0",
-            "isstream": "0.1.2",
-            "json-stringify-safe": "5.0.1",
-            "mime-types": "2.1.18",
-            "oauth-sign": "0.8.2",
-            "performance-now": "2.1.0",
-            "qs": "6.5.1",
-            "safe-buffer": "5.1.1",
-            "stringstream": "0.0.5",
-            "tough-cookie": "2.3.4",
-            "tunnel-agent": "0.6.0",
-            "uuid": "3.2.1"
-          }
-        },
         "rimraf": {
           "version": "2.6.2",
           "bundled": true,
@@ -6339,6 +6111,10 @@
         },
         "safe-buffer": {
           "version": "5.1.1",
+          "bundled": true
+        },
+        "sax": {
+          "version": "1.2.4",
           "bundled": true
         },
         "semver": {
@@ -6352,27 +6128,6 @@
         "signal-exit": {
           "version": "3.0.2",
           "bundled": true
-        },
-        "sntp": {
-          "version": "2.1.0",
-          "bundled": true,
-          "requires": {
-            "hoek": "4.2.1"
-          }
-        },
-        "sshpk": {
-          "version": "1.14.1",
-          "bundled": true,
-          "requires": {
-            "asn1": "0.2.3",
-            "assert-plus": "1.0.0",
-            "bcrypt-pbkdf": "1.0.1",
-            "dashdash": "1.14.1",
-            "ecc-jsbn": "0.1.1",
-            "getpass": "0.1.7",
-            "jsbn": "0.1.1",
-            "tweetnacl": "0.14.5"
-          }
         },
         "string-width": {
           "version": "1.0.2",
@@ -6390,10 +6145,6 @@
             "safe-buffer": "5.1.1"
           }
         },
-        "stringstream": {
-          "version": "0.0.5",
-          "bundled": true
-        },
         "strip-ansi": {
           "version": "3.0.1",
           "bundled": true,
@@ -6406,67 +6157,27 @@
           "bundled": true
         },
         "tar": {
-          "version": "2.2.1",
+          "version": "4.4.2",
           "bundled": true,
           "requires": {
-            "block-stream": "0.0.9",
-            "fstream": "1.0.11",
-            "inherits": "2.0.3"
+            "chownr": "1.0.1",
+            "fs-minipass": "1.2.5",
+            "minipass": "2.2.4",
+            "minizlib": "1.1.0",
+            "mkdirp": "0.5.1",
+            "safe-buffer": "5.1.2",
+            "yallist": "3.0.2"
+          },
+          "dependencies": {
+            "safe-buffer": {
+              "version": "5.1.2",
+              "bundled": true
+            }
           }
-        },
-        "tar-pack": {
-          "version": "3.4.1",
-          "bundled": true,
-          "requires": {
-            "debug": "2.6.9",
-            "fstream": "1.0.11",
-            "fstream-ignore": "1.0.5",
-            "once": "1.4.0",
-            "readable-stream": "2.3.6",
-            "rimraf": "2.6.2",
-            "tar": "2.2.1",
-            "uid-number": "0.0.6"
-          }
-        },
-        "tough-cookie": {
-          "version": "2.3.4",
-          "bundled": true,
-          "requires": {
-            "punycode": "1.4.1"
-          }
-        },
-        "tunnel-agent": {
-          "version": "0.6.0",
-          "bundled": true,
-          "requires": {
-            "safe-buffer": "5.1.1"
-          }
-        },
-        "tweetnacl": {
-          "version": "0.14.5",
-          "bundled": true,
-          "optional": true
-        },
-        "uid-number": {
-          "version": "0.0.6",
-          "bundled": true
         },
         "util-deprecate": {
           "version": "1.0.2",
           "bundled": true
-        },
-        "uuid": {
-          "version": "3.2.1",
-          "bundled": true
-        },
-        "verror": {
-          "version": "1.10.0",
-          "bundled": true,
-          "requires": {
-            "assert-plus": "1.0.0",
-            "core-util-is": "1.0.2",
-            "extsprintf": "1.3.0"
-          }
         },
         "wide-align": {
           "version": "1.1.2",
@@ -6477,6 +6188,10 @@
         },
         "wrappy": {
           "version": "1.0.2",
+          "bundled": true
+        },
+        "yallist": {
+          "version": "3.0.2",
           "bundled": true
         }
       }
@@ -6698,9 +6413,9 @@
       }
     },
     "iconv-lite": {
-      "version": "0.4.21",
-      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.21.tgz",
-      "integrity": "sha512-En5V9za5mBt2oUA03WGD3TwDv0MKAruqsuxstbMUZaj9W9k/m1CV/9py3l0L5kw9Bln8fdHQmzHSYtvpvTLpKw==",
+      "version": "0.4.22",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.22.tgz",
+      "integrity": "sha512-1AinFBeDTnsvVEP+V1QBlHpM1UZZl7gWB6fcz7B1Ho+LI1dUh2sSrxoCfVt2PinRHzXAziSniEV3P7JbTDHcXA==",
       "dev": true,
       "requires": {
         "safer-buffer": "2.1.2"
@@ -7834,9 +7549,9 @@
       }
     },
     "merge2": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/merge2/-/merge2-1.2.1.tgz",
-      "integrity": "sha512-wUqcG5pxrAcaFI1lkqkMnk3Q7nUxV/NWfpAFSeWUwG9TRODnBDCUHa75mi3o3vLWQ5N4CQERWCauSlP0I3ZqUg=="
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/merge2/-/merge2-1.2.2.tgz",
+      "integrity": "sha512-bgM8twH86rWni21thii6WCMQMRMmwqqdW3sGWi9IipnVAszdLXRjwDwAnyrVXo6DuP3AjRMMttZKUB48QWIFGg=="
     },
     "methods": {
       "version": "1.1.2",
@@ -11325,7 +11040,7 @@
       "resolved": "https://registry.npmjs.org/power-assert-context-formatter/-/power-assert-context-formatter-1.1.1.tgz",
       "integrity": "sha1-7bo1LT7YpgMRTWZyZazOYNaJzN8=",
       "requires": {
-        "core-js": "2.5.5",
+        "core-js": "2.5.6",
         "power-assert-context-traversal": "1.1.1"
       }
     },
@@ -11336,7 +11051,7 @@
       "requires": {
         "acorn": "4.0.13",
         "acorn-es7-plugin": "1.1.7",
-        "core-js": "2.5.5",
+        "core-js": "2.5.6",
         "espurify": "1.7.0",
         "estraverse": "4.2.0"
       }
@@ -11346,7 +11061,7 @@
       "resolved": "https://registry.npmjs.org/power-assert-context-traversal/-/power-assert-context-traversal-1.1.1.tgz",
       "integrity": "sha1-iMq8oNE7Y1nwfT0+ivppkmRXftk=",
       "requires": {
-        "core-js": "2.5.5",
+        "core-js": "2.5.6",
         "estraverse": "4.2.0"
       }
     },
@@ -11355,7 +11070,7 @@
       "resolved": "https://registry.npmjs.org/power-assert-formatter/-/power-assert-formatter-1.4.1.tgz",
       "integrity": "sha1-XcEl7VCj37HdomwZNH879Y7CiEo=",
       "requires": {
-        "core-js": "2.5.5",
+        "core-js": "2.5.6",
         "power-assert-context-formatter": "1.1.1",
         "power-assert-context-reducer-ast": "1.1.2",
         "power-assert-renderer-assertion": "1.1.1",
@@ -11383,7 +11098,7 @@
       "resolved": "https://registry.npmjs.org/power-assert-renderer-comparison/-/power-assert-renderer-comparison-1.1.1.tgz",
       "integrity": "sha1-10Odl9hRVr5OMKAPL7WnJRTOPAg=",
       "requires": {
-        "core-js": "2.5.5",
+        "core-js": "2.5.6",
         "diff-match-patch": "1.0.0",
         "power-assert-renderer-base": "1.1.1",
         "stringifier": "1.3.0",
@@ -11395,7 +11110,7 @@
       "resolved": "https://registry.npmjs.org/power-assert-renderer-diagram/-/power-assert-renderer-diagram-1.1.2.tgz",
       "integrity": "sha1-ZV+PcRk1qbbVQbhjJ2VHF8Y3qYY=",
       "requires": {
-        "core-js": "2.5.5",
+        "core-js": "2.5.6",
         "power-assert-renderer-base": "1.1.1",
         "power-assert-util-string-width": "1.1.1",
         "stringifier": "1.3.0"
@@ -11492,7 +11207,7 @@
         "@protobufjs/pool": "1.1.0",
         "@protobufjs/utf8": "1.1.0",
         "@types/long": "3.0.32",
-        "@types/node": "8.10.11",
+        "@types/node": "8.10.12",
         "long": "4.0.0"
       }
     },
@@ -11518,9 +11233,9 @@
       "integrity": "sha1-wNWmOycYgArY4esPpSachN1BhF4="
     },
     "qs": {
-      "version": "6.5.1",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.1.tgz",
-      "integrity": "sha512-eRzhrN1WSINYCDCbrz796z37LOe3m5tmW7RQf6oBntukAG1nmovJvhnwHHRMAfeoItc1m2Hk02WER2aQ/iqs+A=="
+      "version": "6.5.2",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.2.tgz",
+      "integrity": "sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA=="
     },
     "query-string": {
       "version": "5.1.1",
@@ -11795,7 +11510,7 @@
         "mime-types": "2.1.18",
         "oauth-sign": "0.8.2",
         "performance-now": "2.1.0",
-        "qs": "6.5.1",
+        "qs": "6.5.2",
         "safe-buffer": "5.1.2",
         "stringstream": "0.0.5",
         "tough-cookie": "2.3.4",
@@ -12405,7 +12120,7 @@
       "resolved": "https://registry.npmjs.org/stringifier/-/stringifier-1.3.0.tgz",
       "integrity": "sha1-3vGDQvaTPbDy2/yaoCF1tEjBeVk=",
       "requires": {
-        "core-js": "2.5.5",
+        "core-js": "2.5.6",
         "traverse": "0.6.6",
         "type-name": "2.0.2"
       }
@@ -12473,7 +12188,7 @@
         "formidable": "1.2.1",
         "methods": "1.1.2",
         "mime": "1.6.0",
-        "qs": "6.5.1",
+        "qs": "6.5.2",
         "readable-stream": "2.3.6"
       },
       "dependencies": {

--- a/samples/package-lock.json
+++ b/samples/package-lock.json
@@ -1725,7 +1725,7 @@
           "bundled": true
         },
         "@types/node": {
-          "version": "8.10.11",
+          "version": "8.10.12",
           "bundled": true
         },
         "acorn": {
@@ -2359,7 +2359,7 @@
             "babel-generator": "6.26.1",
             "babylon": "6.18.0",
             "call-matcher": "1.0.1",
-            "core-js": "2.5.5",
+            "core-js": "2.5.6",
             "espower-location-detector": "1.0.0",
             "espurify": "1.7.0",
             "estraverse": "4.2.0"
@@ -2476,7 +2476,7 @@
           "requires": {
             "babel-core": "6.26.3",
             "babel-runtime": "6.26.0",
-            "core-js": "2.5.5",
+            "core-js": "2.5.6",
             "home-or-tmp": "2.0.0",
             "lodash": "4.17.10",
             "mkdirp": "0.5.1",
@@ -2496,7 +2496,7 @@
           "version": "6.26.0",
           "bundled": true,
           "requires": {
-            "core-js": "2.5.5",
+            "core-js": "2.5.6",
             "regenerator-runtime": "0.11.1"
           }
         },
@@ -2789,7 +2789,7 @@
           "version": "1.0.1",
           "bundled": true,
           "requires": {
-            "core-js": "2.5.5",
+            "core-js": "2.5.6",
             "deep-equal": "1.0.1",
             "espurify": "1.7.0",
             "estraverse": "4.2.0"
@@ -3159,7 +3159,7 @@
           }
         },
         "core-js": {
-          "version": "2.5.5",
+          "version": "2.5.6",
           "bundled": true
         },
         "core-util-is": {
@@ -3423,7 +3423,7 @@
           "bundled": true
         },
         "duplexify": {
-          "version": "3.5.4",
+          "version": "3.6.0",
           "bundled": true,
           "requires": {
             "end-of-stream": "1.4.1",
@@ -3456,7 +3456,7 @@
           "version": "1.2.3",
           "bundled": true,
           "requires": {
-            "core-js": "2.5.5",
+            "core-js": "2.5.6",
             "empower-core": "0.6.2"
           }
         },
@@ -3472,7 +3472,7 @@
           "bundled": true,
           "requires": {
             "call-signature": "0.0.2",
-            "core-js": "2.5.5"
+            "core-js": "2.5.6"
           }
         },
         "end-of-stream": {
@@ -3821,7 +3821,7 @@
           "version": "1.7.0",
           "bundled": true,
           "requires": {
-            "core-js": "2.5.5"
+            "core-js": "2.5.6"
           }
         },
         "esquery": {
@@ -3963,7 +3963,7 @@
           "bundled": true,
           "requires": {
             "chardet": "0.4.2",
-            "iconv-lite": "0.4.21",
+            "iconv-lite": "0.4.22",
             "tmp": "0.0.33"
           }
         },
@@ -4039,7 +4039,7 @@
             "@mrmlnc/readdir-enhanced": "2.2.1",
             "glob-parent": "3.1.0",
             "is-glob": "4.0.0",
-            "merge2": "1.2.1",
+            "merge2": "1.2.2",
             "micromatch": "3.1.10"
           }
         },
@@ -4359,12 +4359,12 @@
           "version": "0.16.1",
           "bundled": true,
           "requires": {
-            "duplexify": "3.5.4",
+            "duplexify": "3.6.0",
             "extend": "3.0.1",
             "globby": "8.0.1",
             "google-auto-auth": "0.10.1",
             "google-proto-files": "0.15.1",
-            "grpc": "1.11.0",
+            "grpc": "1.11.3",
             "is-stream-ended": "0.1.4",
             "lodash": "4.17.10",
             "protobufjs": "6.8.6",
@@ -4447,28 +4447,18 @@
           "bundled": true
         },
         "grpc": {
-          "version": "1.11.0",
+          "version": "1.11.3",
           "bundled": true,
           "requires": {
             "lodash": "4.17.10",
             "nan": "2.10.0",
-            "node-pre-gyp": "0.7.0",
+            "node-pre-gyp": "0.10.0",
             "protobufjs": "5.0.2"
           },
           "dependencies": {
             "abbrev": {
               "version": "1.1.1",
               "bundled": true
-            },
-            "ajv": {
-              "version": "5.5.2",
-              "bundled": true,
-              "requires": {
-                "co": "4.6.0",
-                "fast-deep-equal": "1.1.0",
-                "fast-json-stable-stringify": "2.0.0",
-                "json-schema-traverse": "0.3.1"
-              }
             },
             "ansi-regex": {
               "version": "2.1.1",
@@ -4486,51 +4476,9 @@
                 "readable-stream": "2.3.6"
               }
             },
-            "asn1": {
-              "version": "0.2.3",
-              "bundled": true
-            },
-            "assert-plus": {
-              "version": "1.0.0",
-              "bundled": true
-            },
-            "asynckit": {
-              "version": "0.4.0",
-              "bundled": true
-            },
-            "aws-sign2": {
-              "version": "0.7.0",
-              "bundled": true
-            },
-            "aws4": {
-              "version": "1.7.0",
-              "bundled": true
-            },
             "balanced-match": {
               "version": "1.0.0",
               "bundled": true
-            },
-            "bcrypt-pbkdf": {
-              "version": "1.0.1",
-              "bundled": true,
-              "optional": true,
-              "requires": {
-                "tweetnacl": "0.14.5"
-              }
-            },
-            "block-stream": {
-              "version": "0.0.9",
-              "bundled": true,
-              "requires": {
-                "inherits": "2.0.3"
-              }
-            },
-            "boom": {
-              "version": "4.3.1",
-              "bundled": true,
-              "requires": {
-                "hoek": "4.2.1"
-              }
             },
             "brace-expansion": {
               "version": "1.1.11",
@@ -4540,24 +4488,13 @@
                 "concat-map": "0.0.1"
               }
             },
-            "caseless": {
-              "version": "0.12.0",
-              "bundled": true
-            },
-            "co": {
-              "version": "4.6.0",
+            "chownr": {
+              "version": "1.0.1",
               "bundled": true
             },
             "code-point-at": {
               "version": "1.1.0",
               "bundled": true
-            },
-            "combined-stream": {
-              "version": "1.0.6",
-              "bundled": true,
-              "requires": {
-                "delayed-stream": "1.0.0"
-              }
             },
             "concat-map": {
               "version": "0.0.1",
@@ -4571,29 +4508,6 @@
               "version": "1.0.2",
               "bundled": true
             },
-            "cryptiles": {
-              "version": "3.1.2",
-              "bundled": true,
-              "requires": {
-                "boom": "5.2.0"
-              },
-              "dependencies": {
-                "boom": {
-                  "version": "5.2.0",
-                  "bundled": true,
-                  "requires": {
-                    "hoek": "4.2.1"
-                  }
-                }
-              }
-            },
-            "dashdash": {
-              "version": "1.14.1",
-              "bundled": true,
-              "requires": {
-                "assert-plus": "1.0.0"
-              }
-            },
             "debug": {
               "version": "2.6.9",
               "bundled": true,
@@ -4602,11 +4516,7 @@
               }
             },
             "deep-extend": {
-              "version": "0.4.2",
-              "bundled": true
-            },
-            "delayed-stream": {
-              "version": "1.0.0",
+              "version": "0.5.1",
               "bundled": true
             },
             "delegates": {
@@ -4617,65 +4527,16 @@
               "version": "1.0.3",
               "bundled": true
             },
-            "ecc-jsbn": {
-              "version": "0.1.1",
-              "bundled": true,
-              "optional": true,
-              "requires": {
-                "jsbn": "0.1.1"
-              }
-            },
-            "extend": {
-              "version": "3.0.1",
-              "bundled": true
-            },
-            "extsprintf": {
-              "version": "1.3.0",
-              "bundled": true
-            },
-            "fast-deep-equal": {
-              "version": "1.1.0",
-              "bundled": true
-            },
-            "fast-json-stable-stringify": {
-              "version": "2.0.0",
-              "bundled": true
-            },
-            "forever-agent": {
-              "version": "0.6.1",
-              "bundled": true
-            },
-            "form-data": {
-              "version": "2.3.2",
+            "fs-minipass": {
+              "version": "1.2.5",
               "bundled": true,
               "requires": {
-                "asynckit": "0.4.0",
-                "combined-stream": "1.0.6",
-                "mime-types": "2.1.18"
+                "minipass": "2.2.4"
               }
             },
             "fs.realpath": {
               "version": "1.0.0",
               "bundled": true
-            },
-            "fstream": {
-              "version": "1.0.11",
-              "bundled": true,
-              "requires": {
-                "graceful-fs": "4.1.11",
-                "inherits": "2.0.3",
-                "mkdirp": "0.5.1",
-                "rimraf": "2.6.2"
-              }
-            },
-            "fstream-ignore": {
-              "version": "1.0.5",
-              "bundled": true,
-              "requires": {
-                "fstream": "1.0.11",
-                "inherits": "2.0.3",
-                "minimatch": "3.0.4"
-              }
             },
             "gauge": {
               "version": "2.7.4",
@@ -4691,13 +4552,6 @@
                 "wide-align": "1.1.2"
               }
             },
-            "getpass": {
-              "version": "0.1.7",
-              "bundled": true,
-              "requires": {
-                "assert-plus": "1.0.0"
-              }
-            },
             "glob": {
               "version": "7.1.2",
               "bundled": true,
@@ -4710,47 +4564,19 @@
                 "path-is-absolute": "1.0.1"
               }
             },
-            "graceful-fs": {
-              "version": "4.1.11",
-              "bundled": true
-            },
-            "har-schema": {
-              "version": "2.0.0",
-              "bundled": true
-            },
-            "har-validator": {
-              "version": "5.0.3",
-              "bundled": true,
-              "requires": {
-                "ajv": "5.5.2",
-                "har-schema": "2.0.0"
-              }
-            },
             "has-unicode": {
               "version": "2.0.1",
               "bundled": true
             },
-            "hawk": {
-              "version": "6.0.2",
-              "bundled": true,
-              "requires": {
-                "boom": "4.3.1",
-                "cryptiles": "3.1.2",
-                "hoek": "4.2.1",
-                "sntp": "2.1.0"
-              }
-            },
-            "hoek": {
-              "version": "4.2.1",
+            "iconv-lite": {
+              "version": "0.4.19",
               "bundled": true
             },
-            "http-signature": {
-              "version": "1.2.0",
+            "ignore-walk": {
+              "version": "3.0.1",
               "bundled": true,
               "requires": {
-                "assert-plus": "1.0.0",
-                "jsprim": "1.4.1",
-                "sshpk": "1.14.1"
+                "minimatch": "3.0.4"
               }
             },
             "inflight": {
@@ -4776,55 +4602,9 @@
                 "number-is-nan": "1.0.1"
               }
             },
-            "is-typedarray": {
-              "version": "1.0.0",
-              "bundled": true
-            },
             "isarray": {
               "version": "1.0.0",
               "bundled": true
-            },
-            "isstream": {
-              "version": "0.1.2",
-              "bundled": true
-            },
-            "jsbn": {
-              "version": "0.1.1",
-              "bundled": true,
-              "optional": true
-            },
-            "json-schema": {
-              "version": "0.2.3",
-              "bundled": true
-            },
-            "json-schema-traverse": {
-              "version": "0.3.1",
-              "bundled": true
-            },
-            "json-stringify-safe": {
-              "version": "5.0.1",
-              "bundled": true
-            },
-            "jsprim": {
-              "version": "1.4.1",
-              "bundled": true,
-              "requires": {
-                "assert-plus": "1.0.0",
-                "extsprintf": "1.3.0",
-                "json-schema": "0.2.3",
-                "verror": "1.10.0"
-              }
-            },
-            "mime-db": {
-              "version": "1.33.0",
-              "bundled": true
-            },
-            "mime-types": {
-              "version": "2.1.18",
-              "bundled": true,
-              "requires": {
-                "mime-db": "1.33.0"
-              }
             },
             "minimatch": {
               "version": "3.0.4",
@@ -4836,6 +4616,21 @@
             "minimist": {
               "version": "1.2.0",
               "bundled": true
+            },
+            "minipass": {
+              "version": "2.2.4",
+              "bundled": true,
+              "requires": {
+                "safe-buffer": "5.1.1",
+                "yallist": "3.0.2"
+              }
+            },
+            "minizlib": {
+              "version": "1.1.0",
+              "bundled": true,
+              "requires": {
+                "minipass": "2.2.4"
+              }
             },
             "mkdirp": {
               "version": "0.5.1",
@@ -4854,20 +4649,29 @@
               "version": "2.0.0",
               "bundled": true
             },
+            "needle": {
+              "version": "2.2.1",
+              "bundled": true,
+              "requires": {
+                "debug": "2.6.9",
+                "iconv-lite": "0.4.19",
+                "sax": "1.2.4"
+              }
+            },
             "node-pre-gyp": {
-              "version": "0.7.0",
+              "version": "0.10.0",
               "bundled": true,
               "requires": {
                 "detect-libc": "1.0.3",
                 "mkdirp": "0.5.1",
+                "needle": "2.2.1",
                 "nopt": "4.0.1",
+                "npm-packlist": "1.1.10",
                 "npmlog": "4.1.2",
-                "rc": "1.2.6",
-                "request": "2.83.0",
+                "rc": "1.2.7",
                 "rimraf": "2.6.2",
                 "semver": "5.5.0",
-                "tar": "2.2.1",
-                "tar-pack": "3.4.1"
+                "tar": "4.4.2"
               }
             },
             "nopt": {
@@ -4876,6 +4680,18 @@
               "requires": {
                 "abbrev": "1.1.1",
                 "osenv": "0.1.5"
+              }
+            },
+            "npm-bundled": {
+              "version": "1.0.3",
+              "bundled": true
+            },
+            "npm-packlist": {
+              "version": "1.1.10",
+              "bundled": true,
+              "requires": {
+                "ignore-walk": "3.0.1",
+                "npm-bundled": "1.0.3"
               }
             },
             "npmlog": {
@@ -4890,10 +4706,6 @@
             },
             "number-is-nan": {
               "version": "1.0.1",
-              "bundled": true
-            },
-            "oauth-sign": {
-              "version": "0.8.2",
               "bundled": true
             },
             "object-assign": {
@@ -4927,10 +4739,6 @@
               "version": "1.0.1",
               "bundled": true
             },
-            "performance-now": {
-              "version": "2.1.0",
-              "bundled": true
-            },
             "process-nextick-args": {
               "version": "2.0.0",
               "bundled": true
@@ -4945,19 +4753,11 @@
                 "yargs": "3.32.0"
               }
             },
-            "punycode": {
-              "version": "1.4.1",
-              "bundled": true
-            },
-            "qs": {
-              "version": "6.5.1",
-              "bundled": true
-            },
             "rc": {
-              "version": "1.2.6",
+              "version": "1.2.7",
               "bundled": true,
               "requires": {
-                "deep-extend": "0.4.2",
+                "deep-extend": "0.5.1",
                 "ini": "1.3.5",
                 "minimist": "1.2.0",
                 "strip-json-comments": "2.0.1"
@@ -4976,34 +4776,6 @@
                 "util-deprecate": "1.0.2"
               }
             },
-            "request": {
-              "version": "2.83.0",
-              "bundled": true,
-              "requires": {
-                "aws-sign2": "0.7.0",
-                "aws4": "1.7.0",
-                "caseless": "0.12.0",
-                "combined-stream": "1.0.6",
-                "extend": "3.0.1",
-                "forever-agent": "0.6.1",
-                "form-data": "2.3.2",
-                "har-validator": "5.0.3",
-                "hawk": "6.0.2",
-                "http-signature": "1.2.0",
-                "is-typedarray": "1.0.0",
-                "isstream": "0.1.2",
-                "json-stringify-safe": "5.0.1",
-                "mime-types": "2.1.18",
-                "oauth-sign": "0.8.2",
-                "performance-now": "2.1.0",
-                "qs": "6.5.1",
-                "safe-buffer": "5.1.1",
-                "stringstream": "0.0.5",
-                "tough-cookie": "2.3.4",
-                "tunnel-agent": "0.6.0",
-                "uuid": "3.2.1"
-              }
-            },
             "rimraf": {
               "version": "2.6.2",
               "bundled": true,
@@ -5013,6 +4785,10 @@
             },
             "safe-buffer": {
               "version": "5.1.1",
+              "bundled": true
+            },
+            "sax": {
+              "version": "1.2.4",
               "bundled": true
             },
             "semver": {
@@ -5026,27 +4802,6 @@
             "signal-exit": {
               "version": "3.0.2",
               "bundled": true
-            },
-            "sntp": {
-              "version": "2.1.0",
-              "bundled": true,
-              "requires": {
-                "hoek": "4.2.1"
-              }
-            },
-            "sshpk": {
-              "version": "1.14.1",
-              "bundled": true,
-              "requires": {
-                "asn1": "0.2.3",
-                "assert-plus": "1.0.0",
-                "bcrypt-pbkdf": "1.0.1",
-                "dashdash": "1.14.1",
-                "ecc-jsbn": "0.1.1",
-                "getpass": "0.1.7",
-                "jsbn": "0.1.1",
-                "tweetnacl": "0.14.5"
-              }
             },
             "string-width": {
               "version": "1.0.2",
@@ -5064,10 +4819,6 @@
                 "safe-buffer": "5.1.1"
               }
             },
-            "stringstream": {
-              "version": "0.0.5",
-              "bundled": true
-            },
             "strip-ansi": {
               "version": "3.0.1",
               "bundled": true,
@@ -5080,67 +4831,27 @@
               "bundled": true
             },
             "tar": {
-              "version": "2.2.1",
+              "version": "4.4.2",
               "bundled": true,
               "requires": {
-                "block-stream": "0.0.9",
-                "fstream": "1.0.11",
-                "inherits": "2.0.3"
+                "chownr": "1.0.1",
+                "fs-minipass": "1.2.5",
+                "minipass": "2.2.4",
+                "minizlib": "1.1.0",
+                "mkdirp": "0.5.1",
+                "safe-buffer": "5.1.2",
+                "yallist": "3.0.2"
+              },
+              "dependencies": {
+                "safe-buffer": {
+                  "version": "5.1.2",
+                  "bundled": true
+                }
               }
-            },
-            "tar-pack": {
-              "version": "3.4.1",
-              "bundled": true,
-              "requires": {
-                "debug": "2.6.9",
-                "fstream": "1.0.11",
-                "fstream-ignore": "1.0.5",
-                "once": "1.4.0",
-                "readable-stream": "2.3.6",
-                "rimraf": "2.6.2",
-                "tar": "2.2.1",
-                "uid-number": "0.0.6"
-              }
-            },
-            "tough-cookie": {
-              "version": "2.3.4",
-              "bundled": true,
-              "requires": {
-                "punycode": "1.4.1"
-              }
-            },
-            "tunnel-agent": {
-              "version": "0.6.0",
-              "bundled": true,
-              "requires": {
-                "safe-buffer": "5.1.1"
-              }
-            },
-            "tweetnacl": {
-              "version": "0.14.5",
-              "bundled": true,
-              "optional": true
-            },
-            "uid-number": {
-              "version": "0.0.6",
-              "bundled": true
             },
             "util-deprecate": {
               "version": "1.0.2",
               "bundled": true
-            },
-            "uuid": {
-              "version": "3.2.1",
-              "bundled": true
-            },
-            "verror": {
-              "version": "1.10.0",
-              "bundled": true,
-              "requires": {
-                "assert-plus": "1.0.0",
-                "core-util-is": "1.0.2",
-                "extsprintf": "1.3.0"
-              }
             },
             "wide-align": {
               "version": "1.1.2",
@@ -5151,6 +4862,10 @@
             },
             "wrappy": {
               "version": "1.0.2",
+              "bundled": true
+            },
+            "yallist": {
+              "version": "3.0.2",
               "bundled": true
             }
           }
@@ -5333,7 +5048,7 @@
           }
         },
         "iconv-lite": {
-          "version": "0.4.21",
+          "version": "0.4.22",
           "bundled": true,
           "requires": {
             "safer-buffer": "2.1.2"
@@ -6213,7 +5928,7 @@
           }
         },
         "merge2": {
-          "version": "1.2.1",
+          "version": "1.2.2",
           "bundled": true
         },
         "methods": {
@@ -9204,7 +8919,7 @@
           "version": "1.1.1",
           "bundled": true,
           "requires": {
-            "core-js": "2.5.5",
+            "core-js": "2.5.6",
             "power-assert-context-traversal": "1.1.1"
           }
         },
@@ -9214,7 +8929,7 @@
           "requires": {
             "acorn": "4.0.13",
             "acorn-es7-plugin": "1.1.7",
-            "core-js": "2.5.5",
+            "core-js": "2.5.6",
             "espurify": "1.7.0",
             "estraverse": "4.2.0"
           }
@@ -9223,7 +8938,7 @@
           "version": "1.1.1",
           "bundled": true,
           "requires": {
-            "core-js": "2.5.5",
+            "core-js": "2.5.6",
             "estraverse": "4.2.0"
           }
         },
@@ -9231,7 +8946,7 @@
           "version": "1.4.1",
           "bundled": true,
           "requires": {
-            "core-js": "2.5.5",
+            "core-js": "2.5.6",
             "power-assert-context-formatter": "1.1.1",
             "power-assert-context-reducer-ast": "1.1.2",
             "power-assert-renderer-assertion": "1.1.1",
@@ -9256,7 +8971,7 @@
           "version": "1.1.1",
           "bundled": true,
           "requires": {
-            "core-js": "2.5.5",
+            "core-js": "2.5.6",
             "diff-match-patch": "1.0.0",
             "power-assert-renderer-base": "1.1.1",
             "stringifier": "1.3.0",
@@ -9267,7 +8982,7 @@
           "version": "1.1.2",
           "bundled": true,
           "requires": {
-            "core-js": "2.5.5",
+            "core-js": "2.5.6",
             "power-assert-renderer-base": "1.1.1",
             "power-assert-util-string-width": "1.1.1",
             "stringifier": "1.3.0"
@@ -9344,7 +9059,7 @@
             "@protobufjs/pool": "1.1.0",
             "@protobufjs/utf8": "1.1.0",
             "@types/long": "3.0.32",
-            "@types/node": "8.10.11",
+            "@types/node": "8.10.12",
             "long": "4.0.0"
           }
         },
@@ -9366,7 +9081,7 @@
           "bundled": true
         },
         "qs": {
-          "version": "6.5.1",
+          "version": "6.5.2",
           "bundled": true
         },
         "query-string": {
@@ -9589,7 +9304,7 @@
             "mime-types": "2.1.18",
             "oauth-sign": "0.8.2",
             "performance-now": "2.1.0",
-            "qs": "6.5.1",
+            "qs": "6.5.2",
             "safe-buffer": "5.1.2",
             "stringstream": "0.0.5",
             "tough-cookie": "2.3.4",
@@ -10081,7 +9796,7 @@
           "version": "1.3.0",
           "bundled": true,
           "requires": {
-            "core-js": "2.5.5",
+            "core-js": "2.5.6",
             "traverse": "0.6.6",
             "type-name": "2.0.2"
           }
@@ -10135,7 +9850,7 @@
             "formidable": "1.2.1",
             "methods": "1.1.2",
             "mime": "1.6.0",
-            "qs": "6.5.1",
+            "qs": "6.5.2",
             "readable-stream": "2.3.6"
           },
           "dependencies": {
@@ -11347,7 +11062,7 @@
         "babel-generator": "6.26.1",
         "babylon": "6.18.0",
         "call-matcher": "1.0.1",
-        "core-js": "2.5.5",
+        "core-js": "2.5.6",
         "espower-location-detector": "1.0.0",
         "espurify": "1.7.0",
         "estraverse": "4.2.0"
@@ -11494,7 +11209,7 @@
       "requires": {
         "babel-core": "6.26.3",
         "babel-runtime": "6.26.0",
-        "core-js": "2.5.5",
+        "core-js": "2.5.6",
         "home-or-tmp": "2.0.0",
         "lodash": "4.17.5",
         "mkdirp": "0.5.1",
@@ -11518,7 +11233,7 @@
       "integrity": "sha1-llxwWGaOgrVde/4E/yM3vItWR/4=",
       "dev": true,
       "requires": {
-        "core-js": "2.5.5",
+        "core-js": "2.5.6",
         "regenerator-runtime": "0.11.1"
       }
     },
@@ -11729,7 +11444,7 @@
       "integrity": "sha1-UTTQd5hPcSpU2tPL9i3ijc5BbKg=",
       "dev": true,
       "requires": {
-        "core-js": "2.5.5",
+        "core-js": "2.5.6",
         "deep-equal": "1.0.1",
         "espurify": "1.7.0",
         "estraverse": "4.2.0"
@@ -12032,9 +11747,9 @@
       }
     },
     "core-js": {
-      "version": "2.5.5",
-      "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.5.5.tgz",
-      "integrity": "sha1-sU3ek2xkDAV5prUMq8wTLdYSfjs=",
+      "version": "2.5.6",
+      "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.5.6.tgz",
+      "integrity": "sha512-lQUVfQi0aLix2xpyjrrJEvfuYCqPc/HwmTKsC/VNf8q0zsjX7SQZtp4+oRONN5Tsur9GDETPjj+Ub2iDiGZfSQ==",
       "dev": true
     },
     "core-util-is": {
@@ -12177,7 +11892,7 @@
       "dev": true,
       "requires": {
         "call-signature": "0.0.2",
-        "core-js": "2.5.5"
+        "core-js": "2.5.6"
       }
     },
     "equal-length": {
@@ -12231,7 +11946,7 @@
       "integrity": "sha1-HFz2y8zDLm9jk4C9T5kfq5up0iY=",
       "dev": true,
       "requires": {
-        "core-js": "2.5.5"
+        "core-js": "2.5.6"
       }
     },
     "estraverse": {
@@ -16093,9 +15808,9 @@
       "dev": true
     },
     "qs": {
-      "version": "6.5.1",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.1.tgz",
-      "integrity": "sha512-eRzhrN1WSINYCDCbrz796z37LOe3m5tmW7RQf6oBntukAG1nmovJvhnwHHRMAfeoItc1m2Hk02WER2aQ/iqs+A==",
+      "version": "6.5.2",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.2.tgz",
+      "integrity": "sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA==",
       "dev": true
     },
     "query-string": {
@@ -16686,7 +16401,7 @@
         "formidable": "1.2.1",
         "methods": "1.1.2",
         "mime": "1.6.0",
-        "qs": "6.5.1",
+        "qs": "6.5.2",
         "readable-stream": "2.3.6"
       }
     },


### PR DESCRIPTION
🔨 update lock files to use the latest gRPC (v1.11.3) and make node10 test use pre-built binary