### PR TITLE
fix: fix the system tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -59,7 +59,7 @@ jobs:
       - image: 'node:6'
         user: node
     steps: &unit_tests_steps
-      - checkout 
+      - checkout
       - run: &npm_install_and_link
           name: Install and link the module
           command: |-
@@ -69,7 +69,7 @@ jobs:
             NPM_CONFIG_PREFIX: /home/node/.npm-global
       - run: npm test
       - run: node_modules/.bin/codecov
-  
+
   node8:
     docker:
       - image: 'node:8'
@@ -153,6 +153,7 @@ jobs:
           name: Run system tests.
           command: npm run system-test
           environment:
+            GCLOUD_PROJECT: long-door-651
             GOOGLE_APPLICATION_CREDENTIALS: .circleci/key.json
       - run:
           name: Remove unencrypted key.

--- a/system-test/dataproc.js
+++ b/system-test/dataproc.js
@@ -12,4 +12,4 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-console.warn('no system-tests available');
+console.warn('no system-tests available 😱');


### PR DESCRIPTION
@alexander-fenster @kinwa91 this is interesting.  It looks like `npm run system-test` is running tests in the smoke test directory.  The smoke tests seem to require a `GCLOUD_PROJECT` env var.  This leaves me with a few questions:

1. What's the difference between a smoke test and a system test?  @alexander-fenster can we just collapse these into one in the generator?
1. Why is this test throwing if there's no `GCLOUD_PROJECT` env var??  We should be able to get it from the credential file that's already there as part of the test.  If not, that's a bug. 
