### PR TITLE
fix: change dataproc success message and test

### DIFF
--- a/samples/createCluster.js
+++ b/samples/createCluster.js
@@ -15,7 +15,7 @@
 // Code for creating a Cloud Dataproc cluster with the Node.js Client Library
 
 function main(projectId, region, clusterName) {
-  // [START create_cluster]
+  // [START dataproc_create_cluster]
   const dataproc = require('@google-cloud/dataproc');
 
   // Create a client with the endpoint set to the desired cluster region
@@ -54,7 +54,7 @@ function main(projectId, region, clusterName) {
 
     // Output a success message
     console.log(`Cluster created successfully: ${response.clusterName}`);
-    // [END create_cluster]
+    // [END dataproc_create_cluster]
   }
 
   createCluster();

--- a/samples/createCluster.js
+++ b/samples/createCluster.js
@@ -29,7 +29,7 @@ function main(projectId, region, clusterName) {
     // region = 'YOUR_CLUSTER_REGION'
     // cluster_name = 'YOUR_CLUSTER_NAME'
 
-    // Create your cluster config
+    // Create the cluster config
     const request = {
       projectId: projectId,
       region: region,
@@ -48,12 +48,12 @@ function main(projectId, region, clusterName) {
       },
     };
 
-    // Create our cluster
+    // Create the cluster
     const [operation] = await client.createCluster(request);
     const [response] = await operation.promise();
 
-    // Output the response
-    console.log(response);
+    // Output a success message
+    console.log(`Cluster created successfully: ${response.clusterName}`);
     // [END create_cluster]
   }
 

--- a/samples/createCluster.js
+++ b/samples/createCluster.js
@@ -16,7 +16,7 @@
 
 function main(projectId, region, clusterName) {
   // [START dataproc_create_cluster]
-  const dataproc = require('@google-cloud/dataproc');
+  const dataproc = require('@google-cloud/dataproc').v1;
 
   // Create a client with the endpoint set to the desired cluster region
   const client = new dataproc.v1.ClusterControllerClient({

--- a/samples/package.json
+++ b/samples/package.json
@@ -14,7 +14,9 @@
     "test": "mocha system-test --timeout 600000"
   },
   "dependencies": {
-    "@google-cloud/dataproc": "^1.4.2"
+    "@google-cloud/dataproc": "^1.4.2",
+    "uuid": "^3.3.3",
+    "yargs": "^14.0.0"
   },
   "devDependencies": {
     "chai": "^4.2.0",

--- a/samples/system-test/createCluster.test.js
+++ b/samples/system-test/createCluster.test.js
@@ -21,7 +21,7 @@ const uuid = require('uuid');
 const region = 'us-central1';
 const clusterName = `test-${uuid()}`;
 
-const dataproc = require('@google-cloud/dataproc');
+const dataproc = require('@google-cloud/dataproc').v1;
 const client = new dataproc.v1.ClusterControllerClient({
   apiEndpoint: `${region}-dataproc.googleapis.com`,
 });

--- a/samples/system-test/createCluster.test.js
+++ b/samples/system-test/createCluster.test.js
@@ -35,7 +35,7 @@ describe('create a dataproc cluster', () => {
     const stdout = execSync(
       `node createCluster.js "${projectId}" "${region}" "${clusterName}"`
     );
-    assert.match(stdout, /clusterUuid/);
+    assert.match(stdout, new RegExp(`${clusterName}`));
   });
 
   after(async () => {


### PR DESCRIPTION
Changed success message of dataproc cluster create, fixed test to match this, fixed region tag to include 'dataproc', changed dataproc imports to explicitly call v1