### PR TITLE
fix: removed 'readme' from synthtool exclusions

### DIFF
--- a/synth.py
+++ b/synth.py
@@ -22,7 +22,7 @@ for version in versions:
   library = gapic.node_library('dataproc', version)
   s.copy(
     library,
-    excludes=['package.json', 'README.md', 'src/index.js',]
+    excludes=['package.json', 'src/index.js',]
   )
 
 common_templates = gcp.CommonTemplates()


### PR DESCRIPTION
This should regenerate `README.md` and `samples/README.md`. Running this locally produced the desired results.