### PR TITLE
feat: adding sample for instantiate inline workflow template

### DIFF
--- a/samples/instantiateInlineWorkflowTemplate.js
+++ b/samples/instantiateInlineWorkflowTemplate.js
@@ -1,4 +1,4 @@
-// Copyright 2019 Google LLC
+// Copyright 2020 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/samples/instantiateInlineWorkflowTemplate.js
+++ b/samples/instantiateInlineWorkflowTemplate.js
@@ -1,0 +1,87 @@
+// Copyright 2019 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// This sample instantiates an inline workflow template using the client
+// library for Cloud Dataproc.
+
+function main(projectId, region) {
+  // [START dataproc_instantiate_inline_workflow_template]
+  const dataproc = require('@google-cloud/dataproc');
+
+  // Create a client with the endpoint set to the desired region
+  const client = new dataproc.v1.WorkflowTemplateServiceClient({
+    apiEndpoint: `${region}-dataproc.googleapis.com`,
+  });
+
+  async function instantiateInlineWorkflowTemplate() {
+    // TODO(developer): Uncomment and set the following variables
+    // projectId = 'YOUR_PROJECT_ID'
+    // region = 'YOUR_REGION'
+
+    // Create the formatted parent.
+    const parent = client.regionPath(projectId, region);
+
+    // Create the template
+    const template = {
+      jobs: [
+        {
+          hadoopJob: {
+            mainJarFileUri:
+              'file:///usr/lib/hadoop-mapreduce/hadoop-mapreduce-examples.jar',
+            args: ['teragen', '1000', 'hdfs:///gen/'],
+          },
+          stepId: 'teragen',
+        },
+        {
+          hadoopJob: {
+            mainJarFileUri:
+              'file:///usr/lib/hadoop-mapreduce/hadoop-mapreduce-examples.jar',
+            args: ['terasort', 'hdfs:///gen/', 'hdfs:///sort/'],
+          },
+          stepId: 'terasort',
+          prerequisiteStepIds: ['teragen'],
+        },
+      ],
+      placement: {
+        managedCluster: {
+          clusterName: 'my-managed-cluster',
+          config: {
+            gceClusterConfig: {
+              // Leave 'zoneUri' empty for 'Auto Zone Placement'
+              // zoneUri: ''
+              zoneUri: 'us-central1-a',
+            },
+          },
+        },
+      },
+    };
+
+    const request = {
+      parent: parent,
+      template: template,
+    };
+
+    // Submit the request to instantiate the workflow from an inline template.
+    const [operation] = await client.instantiateInlineWorkflowTemplate(request);
+    await operation.promise();
+
+    // Output a success message
+    console.log('Workflow ran successfully.');
+    // [END dataproc_instantiate_inline_workflow_template]
+  }
+
+  instantiateInlineWorkflowTemplate();
+}
+
+main(...process.argv.slice(2));

--- a/samples/system-test/instantiateInlineWorkflowTemplate.test.js
+++ b/samples/system-test/instantiateInlineWorkflowTemplate.test.js
@@ -1,4 +1,4 @@
-// Copyright 2019 Google LLC
+// Copyright 2020 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/samples/system-test/instantiateInlineWorkflowTemplate.test.js
+++ b/samples/system-test/instantiateInlineWorkflowTemplate.test.js
@@ -1,0 +1,36 @@
+// Copyright 2019 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+'use strict';
+
+const {assert} = require('chai');
+const {describe, it} = require('mocha');
+const cp = require('child_process');
+
+const projectId = process.env.GCLOUD_PROJECT;
+const region = 'us-central1';
+
+const execSync = cmd =>
+  cp.execSync(cmd, {
+    encoding: 'utf-8',
+  });
+
+describe('instantiate an inline workflow template', () => {
+  it('should instantiate an inline workflow template', async () => {
+    const stdout = execSync(
+      `node instantiateInlineWorkflowTemplate.js "${projectId}" "${region}"`
+    );
+    assert.match(stdout, /successfully/);
+  });
+});


### PR DESCRIPTION
adding a sample for instantiating an inline workflow template

[Original template](https://cloud.google.com/dataproc/docs/concepts/workflows/using-yamls)