### PR TITLE
docs: updated links in protos, fix synth

### DIFF
--- a/protos/google/cloud/dataproc/v1/jobs.proto
+++ b/protos/google/cloud/dataproc/v1/jobs.proto
@@ -435,8 +435,9 @@ message SparkRJob {
 
 // A Dataproc job for running [Presto](https://prestosql.io/) queries.
 // **IMPORTANT**: The [Dataproc Presto Optional
-// Component](/dataproc/docs/concepts/components/presto) must be enabled when
-// the cluster is created to submit a Presto job to the cluster.
+// Component](https://cloud.google.com/dataproc/docs/concepts/components/presto)
+// must be enabled when the cluster is created to submit a Presto job to the
+// cluster.
 message PrestoJob {
   // Required. The sequence of Presto queries to execute, specified as
   // either an HCFS file URI or as a list of queries.

--- a/protos/google/cloud/dataproc/v1beta2/jobs.proto
+++ b/protos/google/cloud/dataproc/v1beta2/jobs.proto
@@ -435,8 +435,9 @@ message SparkRJob {
 
 // A Dataproc job for running [Presto](https://prestosql.io/) queries.
 // **IMPORTANT**: The [Dataproc Presto Optional
-// Component](/dataproc/docs/concepts/components/presto) must be enabled when
-// the cluster is created to submit a Presto job to the cluster.
+// Component](https://cloud.google.com/dataproc/docs/concepts/components/presto)
+// must be enabled when the cluster is created to submit a Presto job to the
+// cluster.
 message PrestoJob {
   // Required. The sequence of Presto queries to execute, specified as
   // either an HCFS file URI or as a list of queries.

--- a/synth.metadata
+++ b/synth.metadata
@@ -3,23 +3,23 @@
     {
       "git": {
         "name": ".",
-        "remote": "https://github.com/googleapis/nodejs-dataproc.git",
-        "sha": "4b84de4a54ea4ac3cbede49ed723480d0d69106d"
+        "remote": "git@github.com:googleapis/nodejs-dataproc.git",
+        "sha": "6f5a2a4de59410837f7bfeec525d7492dda01dd7"
       }
     },
     {
       "git": {
         "name": "googleapis",
         "remote": "https://github.com/googleapis/googleapis.git",
-        "sha": "a3a0bf0f6291d69f2ff3df7fcd63d28ee20ac727",
-        "internalRef": "310060413"
+        "sha": "c1fae183ddeef0c59538863eac611fd679d1b7fb",
+        "internalRef": "314634470"
       }
     },
     {
       "git": {
         "name": "synthtool",
         "remote": "https://github.com/googleapis/synthtool.git",
-        "sha": "be74d3e532faa47eb59f1a0eaebde0860d1d8ab4"
+        "sha": "8b65daa222d193b689279162781baf0aa1f0ffd2"
       }
     }
   ],

--- a/synth.py
+++ b/synth.py
@@ -26,6 +26,7 @@ for version in versions:
             "grpc-service-config": f"google/cloud/dataproc/{version}/dataproc_grpc_service_config.json",
             "package-name": "@google-cloud/dataproc",
             "main-service": "dataproc",
+            "validation": "false",
         },
         proto_path=f'/google/cloud/dataproc/{version}',
     )


### PR DESCRIPTION
Fixes #383. The proto validation failed for this library. Re-running `synthtool` after adding `"validation": "false"` to the generator parameters.