### PR TITLE
chore(samples): no native sleep

### DIFF
--- a/samples/package.json
+++ b/samples/package.json
@@ -15,8 +15,7 @@
   },
   "dependencies": {
     "@google-cloud/dataproc": "^2.1.0",
-    "@google-cloud/storage": "^5.0.0",
-    "sleep": "^6.1.0"
+    "@google-cloud/storage": "^5.0.0"
   },
   "devDependencies": {
     "chai": "^4.2.0",

--- a/samples/quickstart.js
+++ b/samples/quickstart.js
@@ -28,8 +28,6 @@ function main(projectId, region, clusterName, jobFilePath) {
   const dataproc = require('@google-cloud/dataproc');
   const {Storage} = require('@google-cloud/storage');
 
-  const sleep = require('sleep');
-
   // Create a cluster client with the endpoint set to the desired cluster region
   const clusterClient = new dataproc.v1.ClusterControllerClient({
     apiEndpoint: `${region}-dataproc.googleapis.com`,
@@ -111,7 +109,7 @@ function main(projectId, region, clusterName, jobFilePath) {
         );
         break;
       }
-      await sleep.sleep(1);
+      await sleep(1);
       [jobResp] = await jobClient.getJob(jobReq);
     }
 
@@ -147,6 +145,11 @@ function main(projectId, region, clusterName, jobFilePath) {
   }
 
   quickstart();
+}
+
+// Helper function to sleep for the given number of seconds
+function sleep(seconds) {
+  return new Promise(resolve => setTimeout(resolve, seconds * 1000));
 }
 
 const args = process.argv.slice(2);


### PR DESCRIPTION
This sample uses `sleep` NPM module which is actually a native dependency. I don't want users to copy-paste this to their code. `setTimeout` is just better, and native dependencies are bad bad.

The function `sleep` is used just once as `await sleep(1);` in line 112.