### PR TITLE
chore: adding api-dataproc team to codeowners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -6,4 +6,4 @@
 
 
 # The yoshi-nodejs team is the default owner for nodejs repositories.
-*     @googleapis/yoshi-nodejs
+*     @googleapis/yoshi-nodejs @googleapis/api-dataproc

--- a/.repo-metadata.json
+++ b/.repo-metadata.json
@@ -10,5 +10,6 @@
   "product_documentation": "https://cloud.google.com/dataproc",
   "requires_billing": true,
   "name": "dataproc",
-  "issue_tracker": "https://issuetracker.google.com/savedsearches/559745"
+  "issue_tracker": "https://issuetracker.google.com/savedsearches/559745",
+  "codeowner_team": "@googleapis/api-dataproc"
 }


### PR DESCRIPTION
Adding @googlepapis/api-dataproc team to codeowners
