### PR TITLE
docs: (samples) fixing samples for new machine types

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,11 +91,11 @@ function main(projectId, region, clusterName, jobFilePath) {
         config: {
           masterConfig: {
             numInstances: 1,
-            machineTypeUri: 'n1-standard-1',
+            machineTypeUri: 'n1-standard-2',
           },
           workerConfig: {
             numInstances: 2,
-            machineTypeUri: 'n1-standard-1',
+            machineTypeUri: 'n1-standard-2',
           },
         },
       },

--- a/samples/createCluster.js
+++ b/samples/createCluster.js
@@ -49,11 +49,11 @@ function main(
         config: {
           masterConfig: {
             numInstances: 1,
-            machineTypeUri: 'n1-standard-1',
+            machineTypeUri: 'n1-standard-2',
           },
           workerConfig: {
             numInstances: 2,
-            machineTypeUri: 'n1-standard-1',
+            machineTypeUri: 'n1-standard-2',
           },
         },
       },

--- a/samples/quickstart.js
+++ b/samples/quickstart.js
@@ -50,11 +50,11 @@ function main(projectId, region, clusterName, jobFilePath) {
         config: {
           masterConfig: {
             numInstances: 1,
-            machineTypeUri: 'n1-standard-1',
+            machineTypeUri: 'n1-standard-2',
           },
           workerConfig: {
             numInstances: 2,
-            machineTypeUri: 'n1-standard-1',
+            machineTypeUri: 'n1-standard-2',
           },
         },
       },

--- a/samples/system-test/submitJob.test.js
+++ b/samples/system-test/submitJob.test.js
@@ -30,11 +30,11 @@ const cluster = {
     config: {
       masterConfig: {
         numInstances: 1,
-        machineTypeUri: 'n1-standard-1',
+        machineTypeUri: 'n1-standard-2',
       },
       workerConfig: {
         numInstances: 2,
-        machineTypeUri: 'n1-standard-1',
+        machineTypeUri: 'n1-standard-2',
       },
     },
   },


### PR DESCRIPTION
Dataproc 2.0 is the new default image which does not support n1-standard-1. 

These samples are breaking across other repos because the change is with the Dataproc service itself. This fix is preemptive.
